### PR TITLE
add smbus2 as dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
+    install_requires=[
+        "smbus2>=0.3.0",
+    ]
 )


### PR DESCRIPTION
Currently if you install the package via `pip install ...` it does not install smbus2 as dependency which you probably want. Would need a bump in PyPi as well.
This fixes this, although dependencies are now stored at two locations, not a perfect solution but it is a bit complicated, see https://stackoverflow.com/questions/14399534/reference-requirements-txt-for-the-install-requires-kwarg-in-setuptools-setup-py